### PR TITLE
luci-app-cpufreq: ipq807x: switch to use schedutil

### DIFF
--- a/applications/luci-app-cpufreq/root/etc/uci-defaults/cpufreq
+++ b/applications/luci-app-cpufreq/root/etc/uci-defaults/cpufreq
@@ -54,7 +54,7 @@ case "$DISTRIB_TARGET" in
 			# IPQ8071A
 			CPU_MAX_FREQ="1382400"
 		fi
-		uci_write_config 0 ondemand 1017600 $CPU_MAX_FREQ 10 50
+		uci_write_config 0 schedutil 1017600 $CPU_MAX_FREQ
 		;;
 	"mediatek/mt7622")
 		uci_write_config 0 ondemand 600000 1350000 10 50


### PR DESCRIPTION
Based on the latest source tree of robimarko.

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>
(cherry picked from commit 23532a947c2e8c1289e31475aab330109dfeab14)